### PR TITLE
Lock mutex on udp connection close

### DIFF
--- a/src/v720_sta.py
+++ b/src/v720_sta.py
@@ -207,9 +207,10 @@ class v720_sta(log):
             self.__on_tcp_rcv(self._tcp.recv())
         
         if self._udp is not None:
-            self._udp.close()
-            del self._udp
-            self._udp = None
+            with self._udp_mtx:
+                self._udp.close()
+                del self._udp
+                self._udp = None
 
         if self._disconnect_cb is not None and callable(self._disconnect_cb):
             self._disconnect_cb(self)


### PR DESCRIPTION
I run the code a few times and noticed the following crash quite often:
```
raceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/home/szupi/naxclow/a9-v720/src/v720_sta.py", line 232, in __udp_hnd
    self.__on_udp_rcv(self._udp.recv())
  File "/home/szupi/naxclow/a9-v720/src/v720_sta.py", line 241, in __on_udp_rcv
    self._raw_hnd_lst[f'{req.cmd}'](self._udp, data)
  File "/home/szupi/naxclow/a9-v720/src/v720_sta.py", line 470, in __on_mjpg_rcv_hnd
    self.__rtr_tmr_hnd()
  File "/home/szupi/naxclow/a9-v720/src/v720_sta.py", line 418, in __rtr_tmr_hnd
    self.__retransmission_confirm()
  File "/home/szupi/naxclow/a9-v720/src/v720_sta.py", line 432, in __retransmission_confirm
    self._udp.send(pkg.req())
    ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'send'

```

From which I concluded the udp connection has been closed unsafely. I believe this PR fixes this.